### PR TITLE
Implementation job is incorrectly marked as parameterized

### DIFF
--- a/src/main/java/com/joelj/jenkins/eztemplates/utils/TemplateUtils.java
+++ b/src/main/java/com/joelj/jenkins/eztemplates/utils/TemplateUtils.java
@@ -215,7 +215,7 @@ public class TemplateUtils {
 			}
 		}
 
-		return new ParametersDefinitionProperty(result);
+		return result.isEmpty() ? null : new ParametersDefinitionProperty(result);
 	}
 
 	private static AbstractProject synchronizeConfigFiles(AbstractProject implementationProject, AbstractProject templateProject) throws IOException {


### PR DESCRIPTION
When the template job and the implementation both have no parameters, the implementation job is still marked as parameterized after a save of the template or implementation job.
