### PR TITLE
Search project by full name, so that it does not return another project with the same name in a different folder

### DIFF
--- a/src/main/java/com/joelj/jenkins/eztemplates/utils/ProjectUtils.java
+++ b/src/main/java/com/joelj/jenkins/eztemplates/utils/ProjectUtils.java
@@ -78,7 +78,6 @@ public class ProjectUtils {
      */
     @SuppressWarnings("unchecked")
     public static AbstractProject updateProjectWithXmlSource(AbstractProject project, Source source) throws IOException {
-        String projectName = project.getName();
 
         XmlFile configXmlFile = project.getConfigFile();
         AtomicFileWriter out = new AtomicFileWriter(configXmlFile.getFile());
@@ -103,7 +102,7 @@ public class ProjectUtils {
 
             // if everything went well, commit this new version
             out.commit();
-            return ProjectUtils.findProject(projectName);
+            return ProjectUtils.findProject(project.getFullName());
         } finally {
             out.abort(); // don't leave anything behind
         }


### PR DESCRIPTION
In my local Jenkins instance, I have a folder with several templates, and then, for each project, I have the implementations for each of those templates. So the naming convention is:
- Plantillas/Hello  (template called "Hello")
- ProyectoA/Hello (implementation of "Hello" for project A)
- ProyectoD/Hello (implementation of "Hello" for project D)

Suppose that project D is already a implementation, and we want to add now project A / Hello to use the same template. The plugin ez-templates will then get confused, as can be seen below:

nov 14, 2014 1:07:32 PM INFO com.joelj.jenkins.eztemplates.utils.TemplateUtils handleTemplateImplementationSaved
Implementation [ProyectoA » Hello] was saved. Syncing with [Plantillas/Hello].
nov 14, 2014 1:07:32 PM INFO com.joelj.jenkins.eztemplates.utils.TemplateUtils handleTemplateImplementationSaved
BEFORE synchronizeConfigFiles -> ImplementationProject=[**ProyectoA » Hello**]
nov 14, 2014 1:07:32 PM INFO com.joelj.jenkins.eztemplates.utils.ProjectUtils updateProjectWithXmlSource
updateProjectWithXmlSource: findProject('Hello')
nov 14, 2014 1:07:32 PM INFO com.joelj.jenkins.eztemplates.utils.TemplateUtils handleTemplateImplementationSaved
AFTER synchronizeConfigFiles -> ImplementationProject=[**ProyectoD » Hello**]
nov 14, 2014 1:07:32 PM INFO com.joelj.jenkins.eztemplates.utils.TemplateUtils fixProperties
fixProperties -> ImplementationProject)[ProyectoD » Hello], Template=[Plantillas/Hello], implementationIsTemplate=[false]
nov 14, 2014 1:07:32 PM INFO com.joelj.jenkins.eztemplates.utils.TemplateUtils handleTemplateSaved
Template [ProyectoA » Hello] was saved. Syncing implementations.

The fix for this is pretty simple: just pass the full project name to findProject(), which is alredy prepared for it... :smile: 
