### PR TITLE
Support for template variables (Proof of Concept)

### DIFF
--- a/src/main/java/com/joelj/jenkins/eztemplates/TemplateImplementationProperty.java
+++ b/src/main/java/com/joelj/jenkins/eztemplates/TemplateImplementationProperty.java
@@ -1,6 +1,8 @@
 package com.joelj.jenkins.eztemplates;
 
 import com.joelj.jenkins.eztemplates.utils.ProjectUtils;
+
+
 import hudson.Extension;
 import hudson.model.AbstractProject;
 import hudson.model.JobProperty;
@@ -8,12 +10,14 @@ import hudson.model.JobPropertyDescriptor;
 import hudson.util.FormValidation;
 import hudson.util.ListBoxModel;
 import net.sf.json.JSONObject;
+
 import org.apache.commons.lang.StringUtils;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.QueryParameter;
 import org.kohsuke.stapler.StaplerRequest;
 import org.kohsuke.stapler.export.Exported;
 
+import java.io.IOException;
 import java.util.logging.Logger;
 
 public class TemplateImplementationProperty extends JobProperty<AbstractProject<?, ?>> {

--- a/src/main/java/com/joelj/jenkins/eztemplates/TemplateImplementationProperty.java
+++ b/src/main/java/com/joelj/jenkins/eztemplates/TemplateImplementationProperty.java
@@ -25,15 +25,18 @@ public class TemplateImplementationProperty extends JobProperty<AbstractProject<
     private final boolean syncBuildTriggers;
     private final boolean syncDisabled;
     private final boolean syncSecurity;
+    private final String templateVariables;
 
     @DataBoundConstructor
-    public TemplateImplementationProperty(String templateJobName, boolean syncMatrixAxis, boolean syncDescription, boolean syncBuildTriggers, boolean syncDisabled, boolean syncSecurity) {
+    public TemplateImplementationProperty(String templateJobName, boolean syncMatrixAxis, boolean syncDescription, boolean syncBuildTriggers, boolean syncDisabled, boolean syncSecurity, String templateVariables) {
+
         this.templateJobName = templateJobName;
         this.syncMatrixAxis = syncMatrixAxis;
         this.syncDescription = syncDescription;
         this.syncBuildTriggers = syncBuildTriggers;
         this.syncDisabled = syncDisabled;
         this.syncSecurity = syncSecurity;
+        this.templateVariables = templateVariables;
     }
 
     @Exported
@@ -61,10 +64,15 @@ public class TemplateImplementationProperty extends JobProperty<AbstractProject<
     public boolean getSyncDisabled() {
         return syncDisabled;
     }
+    
 
     public boolean getSyncSecurity() {
         return syncSecurity;
     }
+
+    public String getTemplateVariables() {
+        return templateVariables;
+    }   
 
     public AbstractProject findTemplate() {
         return ProjectUtils.findProject(getTemplateJobName());
@@ -83,8 +91,9 @@ public class TemplateImplementationProperty extends JobProperty<AbstractProject<
                 boolean syncBuildTriggers = useTemplate.getBoolean("syncBuildTriggers");
                 boolean syncDisabled = useTemplate.getBoolean("syncDisabled");
                 boolean syncSecurity = useTemplate.getBoolean("syncSecurity");
+                String templateVariables = useTemplate.getString("templateVariables");
 
-                return new TemplateImplementationProperty(templateJobName, syncMatrixAxis, syncDescription, syncBuildTriggers, syncDisabled, syncSecurity);
+                return new TemplateImplementationProperty(templateJobName, syncMatrixAxis, syncDescription, syncBuildTriggers, syncDisabled, syncSecurity, templateVariables);
             }
 
             return null;

--- a/src/main/java/com/joelj/jenkins/eztemplates/utils/ReplaceVariables.java
+++ b/src/main/java/com/joelj/jenkins/eztemplates/utils/ReplaceVariables.java
@@ -1,8 +1,0 @@
-package com.joelj.jenkins.eztemplates.utils;
-
-public class ReplaceVariables {
-
-	public static String toUpper(String orig) {
-		return orig.toUpperCase();
-	}
-}

--- a/src/main/java/com/joelj/jenkins/eztemplates/utils/ReplaceVariables.java
+++ b/src/main/java/com/joelj/jenkins/eztemplates/utils/ReplaceVariables.java
@@ -1,0 +1,8 @@
+package com.joelj.jenkins.eztemplates.utils;
+
+public class ReplaceVariables {
+
+	public static String toUpper(String orig) {
+		return orig.toUpperCase();
+	}
+}

--- a/src/main/java/com/joelj/jenkins/eztemplates/utils/TemplateVariablesUtils.java
+++ b/src/main/java/com/joelj/jenkins/eztemplates/utils/TemplateVariablesUtils.java
@@ -1,0 +1,46 @@
+package com.joelj.jenkins.eztemplates.utils;
+
+import java.io.IOException;
+import java.io.StringReader;
+import java.util.Properties;
+import java.util.logging.Logger;
+
+public class TemplateVariablesUtils {
+	
+    private static final Logger LOG = Logger.getLogger("ez-templates");	
+    
+
+	public static Properties processProperties(String textarea) {
+		Properties prop = new Properties();			
+
+		StringReader reader = new StringReader(textarea);
+
+		try {
+			prop.load(reader);
+		} catch (IOException e) {
+			// FIXME Display error in validation form
+		}
+		
+		return prop;
+	}
+	
+	
+	/* TODO 
+	   + Optimize performance: traverse string just once, interpolating the value for each variable found
+	   + Show interpolation feedback to the user (description below "Template Variables" text area):
+	     - Variables found in template, but not in the implementation.
+	     - Variables found in this implementation, but not defined in the template.
+	*/
+	public static String interpolateVariables(Properties prop, String input) {
+		
+		   for(String key : prop.stringPropertyNames()) {
+			   
+			  input = input.replaceAll("#\\{"+ key +"\\}", prop.getProperty(key));
+			  
+			  LOG.info(String.format("* Variable [%s] = [%s]", key, prop.getProperty(key)));
+		   }		
+		   
+		   return input;
+	}
+	
+}

--- a/src/main/resources/com/joelj/jenkins/eztemplates/TemplateImplementationProperty/config.jelly
+++ b/src/main/resources/com/joelj/jenkins/eztemplates/TemplateImplementationProperty/config.jelly
@@ -14,6 +14,11 @@
 			</f:description>
 		</f:entry>
 
+		<f:entry field="templateVariables" title="${%Template variables}">
+			<f:textarea />
+		</f:entry>
+
+		
 		<f:advanced>
 			<f:entry field="syncDescription" title="${%Sync Description}">
 				<f:checkbox />
@@ -31,5 +36,7 @@
 				<f:checkbox />
 			</f:entry>
 		</f:advanced>
+
+		
 	</f:optionalBlock>
 </j:jelly>


### PR DESCRIPTION
This pull requests implements support for template variables:

**Template:**
![template](https://cloud.githubusercontent.com/assets/2572295/5127510/f4c07ec8-70d4-11e4-9aab-817ad54a6993.png)

**Implementation:**
![implementation](https://cloud.githubusercontent.com/assets/2572295/5127514/fcab7138-70d4-11e4-8018-8099f6f78574.png)

_Disclaimer:_ This solution shouldn't be considered as "definite", but just as a Proof Of Concept.

**Description:** This solution replaces variables marked with the _#{VARIABLE}_ syntax in the template to their corresponding value defined in each of the implementations. Note that the syntax is very similar to that of parameters, but using a hash instead of a dollar symbol.

This solution adds up to and is compatible with job parameters. In fact, both can be used at the same time, each with different purposes:
- Template variables are "static", in that they get their values resolved at design-time, when we save the configuration of the template or implementation.
- Job parameters are "dynamic", and resolved at execution-time, when a user launches the job manually and specifies the values.

Before this PR, ez-template only catered for job parameters, which has several drawbacks for static (design-time) variables:
- The build contract is changed: "Build now" changes to "Build with Parameters". Some plugins may have issues with parameterized builds (e.g. [build-pipeline-plugin](https://issues.jenkins-ci.org/browse/JENKINS-25427))
- Static variables (URL repository, email recipient list for notifications, etc.) and dynamic variables (the server we want to deploy on) are mixed up.
- Static variables can be changed by the user!! (even if he has no configuration privileges)
- Some plugins do not support or have issues with job parameters (e.g. [subversion-plugin](https://issues.jenkins-ci.org/browse/JENKINS-22568))
